### PR TITLE
Add Client Model

### DIFF
--- a/src/main/java/seedu/condonery/MainApp.java
+++ b/src/main/java/seedu/condonery/MainApp.java
@@ -61,7 +61,7 @@ public class MainApp extends Application {
         UserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(config.getUserPrefsFilePath());
         UserPrefs userPrefs = initPrefs(userPrefsStorage);
         PropertyDirectoryStorage propertyDirectoryStorage =
-            new JsonPropertyDirectoryStorage(userPrefs.getPropertyDirectoryFilePath());
+                new JsonPropertyDirectoryStorage(userPrefs.getPropertyDirectoryFilePath());
         ClientDirectoryStorage clientDirectoryStorage =
                 new JsonClientDirectoryStorage(userPrefs.getClientDirectoryFilePath());
         storage = new StorageManager(propertyDirectoryStorage, clientDirectoryStorage, userPrefsStorage);

--- a/src/main/java/seedu/condonery/MainApp.java
+++ b/src/main/java/seedu/condonery/MainApp.java
@@ -15,13 +15,17 @@ import seedu.condonery.commons.util.ConfigUtil;
 import seedu.condonery.commons.util.StringUtil;
 import seedu.condonery.logic.Logic;
 import seedu.condonery.logic.LogicManager;
+import seedu.condonery.model.ClientDirectory;
 import seedu.condonery.model.Model;
 import seedu.condonery.model.ModelManager;
 import seedu.condonery.model.PropertyDirectory;
+import seedu.condonery.model.ReadOnlyClientDirectory;
 import seedu.condonery.model.ReadOnlyPropertyDirectory;
 import seedu.condonery.model.ReadOnlyUserPrefs;
 import seedu.condonery.model.UserPrefs;
 import seedu.condonery.model.util.SampleDataUtil;
+import seedu.condonery.storage.ClientDirectoryStorage;
+import seedu.condonery.storage.JsonClientDirectoryStorage;
 import seedu.condonery.storage.JsonPropertyDirectoryStorage;
 import seedu.condonery.storage.JsonUserPrefsStorage;
 import seedu.condonery.storage.PropertyDirectoryStorage;
@@ -36,7 +40,7 @@ import seedu.condonery.ui.UiManager;
  */
 public class MainApp extends Application {
 
-    public static final Version VERSION = new Version(0, 2, 0, true);
+    public static final Version VERSION = new Version(1, 2, 0, true);
 
     private static final Logger logger = LogsCenter.getLogger(MainApp.class);
 
@@ -48,7 +52,7 @@ public class MainApp extends Application {
 
     @Override
     public void init() throws Exception {
-        logger.info("=============================[ Initializing PropertyDirectory ]===========================");
+        logger.info("=============================[ Initializing Condonery ]===========================");
         super.init();
 
         AppParameters appParameters = AppParameters.parse(getParameters());
@@ -58,7 +62,9 @@ public class MainApp extends Application {
         UserPrefs userPrefs = initPrefs(userPrefsStorage);
         PropertyDirectoryStorage propertyDirectoryStorage =
             new JsonPropertyDirectoryStorage(userPrefs.getPropertyDirectoryFilePath());
-        storage = new StorageManager(propertyDirectoryStorage, userPrefsStorage);
+        ClientDirectoryStorage clientDirectoryStorage =
+                new JsonClientDirectoryStorage(userPrefs.getClientDirectoryFilePath());
+        storage = new StorageManager(propertyDirectoryStorage, clientDirectoryStorage, userPrefsStorage);
 
         initLogging(config);
 
@@ -76,22 +82,41 @@ public class MainApp extends Application {
      */
     private Model initModelManager(Storage storage, ReadOnlyUserPrefs userPrefs) {
         Optional<ReadOnlyPropertyDirectory> propertyDirectoryOptional;
-        ReadOnlyPropertyDirectory initialData;
+        ReadOnlyPropertyDirectory initialPropertyDirectoryData;
+
+        Optional<ReadOnlyClientDirectory> clientDirectoryOptional;
+        ReadOnlyClientDirectory initialClientDirectoryData;
+
         try {
             propertyDirectoryOptional = storage.readPropertyDirectory();
             if (!propertyDirectoryOptional.isPresent()) {
                 logger.info("Data file not found. Will be starting with a sample PropertyDirectory");
             }
-            initialData = propertyDirectoryOptional.orElseGet(SampleDataUtil::getSamplePropertyDirectory);
+            initialPropertyDirectoryData =
+                    propertyDirectoryOptional.orElseGet(SampleDataUtil::getSamplePropertyDirectory);
         } catch (DataConversionException e) {
             logger.warning("Data file not in the correct format. Will be starting with an empty PropertyDirectory");
-            initialData = new PropertyDirectory();
+            initialPropertyDirectoryData = new PropertyDirectory();
         } catch (IOException e) {
             logger.warning("Problem while reading from the file. Will be starting with an empty PropertyDirectory");
-            initialData = new PropertyDirectory();
+            initialPropertyDirectoryData = new PropertyDirectory();
         }
 
-        return new ModelManager(initialData, userPrefs);
+        try {
+            clientDirectoryOptional = storage.readClientDirectory();
+            if (!clientDirectoryOptional.isPresent()) {
+                logger.info("Data file not found. Will be starting with a sample PropertyDirectory");
+            }
+            initialClientDirectoryData = clientDirectoryOptional.orElseGet(SampleDataUtil::getSampleClientDirectory);
+        } catch (DataConversionException e) {
+            logger.warning("Data file not in the correct format. Will be starting with an empty ClientDirectory");
+            initialClientDirectoryData = new ClientDirectory();
+        } catch (IOException e) {
+            logger.warning("Problem while reading from the file. Will be starting with an empty ClientDirectory");
+            initialClientDirectoryData = new ClientDirectory();
+        }
+
+        return new ModelManager(initialPropertyDirectoryData, initialClientDirectoryData, userPrefs);
     }
 
     private void initLogging(Config config) {
@@ -152,7 +177,7 @@ public class MainApp extends Application {
                 + "Using default user prefs");
             initializedPrefs = new UserPrefs();
         } catch (IOException e) {
-            logger.warning("Problem while reading from the file. Will be starting with an empty PropertyDirectory");
+            logger.warning("Problem while reading from the file. Will be starting with an empty UserPrefs");
             initializedPrefs = new UserPrefs();
         }
 
@@ -168,7 +193,7 @@ public class MainApp extends Application {
 
     @Override
     public void start(Stage primaryStage) {
-        logger.info("Starting PropertyDirectory " + MainApp.VERSION);
+        logger.info("Starting Condonery " + MainApp.VERSION);
         ui.start(primaryStage);
     }
 

--- a/src/main/java/seedu/condonery/commons/core/LogsCenter.java
+++ b/src/main/java/seedu/condonery/commons/core/LogsCenter.java
@@ -18,7 +18,7 @@ import java.util.logging.SimpleFormatter;
 public class LogsCenter {
     private static final int MAX_FILE_COUNT = 5;
     private static final int MAX_FILE_SIZE_IN_BYTES = (int) (Math.pow(2, 20) * 5); // 5MB
-    private static final String LOG_FILE = "addressbook.log";
+    private static final String LOG_FILE = "condonery.log";
     private static Level currentLogLevel = Level.INFO;
     private static final Logger logger = LogsCenter.getLogger(LogsCenter.class);
     private static FileHandler fileHandler;

--- a/src/main/java/seedu/condonery/model/ClientDirectory.java
+++ b/src/main/java/seedu/condonery/model/ClientDirectory.java
@@ -1,0 +1,121 @@
+package seedu.condonery.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import javafx.collections.ObservableList;
+import seedu.condonery.model.client.Client;
+import seedu.condonery.model.client.UniqueClientList;
+
+/**
+ * Wraps all data at the Condonery level
+ * Duplicates are not allowed (by .isSameClient comparison)
+ */
+public class ClientDirectory implements ReadOnlyClientDirectory {
+
+    private final UniqueClientList properties;
+
+    /*
+     * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
+     * between constructors. See https://docs.oracle.com/javase/tutorial/java/javaOO/initial.html
+     *
+     * Note that non-static init blocks are not recommended to use. There are other ways to avoid duplication
+     *   among constructors.
+     */
+    {
+        properties = new UniqueClientList();
+    }
+
+    public ClientDirectory() {}
+
+    /**
+     * Creates an ClientDirectory using the Properties in the {@code toBeCopied}
+     */
+    public ClientDirectory(ReadOnlyClientDirectory toBeCopied) {
+        this();
+        resetData(toBeCopied);
+    }
+
+    //// list overwrite operations
+
+    /**
+     * Replaces the contents of the client list with {@code properties}.
+     * {@code properties} must not contain duplicate properties.
+     */
+    public void setProperties(List<Client> properties) {
+        this.properties.setClients(properties);
+    }
+
+    /**
+     * Resets the existing data of this {@code ClientDirectory} with {@code newData}.
+     */
+    public void resetData(ReadOnlyClientDirectory newData) {
+        requireNonNull(newData);
+
+        setProperties(newData.getClientList());
+    }
+
+    //// client-level operations
+
+    /**
+     * Returns true if a client with the same identity as {@code client} exists in the address book.
+     */
+    public boolean hasClient(Client client) {
+        requireNonNull(client);
+        return properties.contains(client);
+    }
+
+    /**
+     * Adds a client to the address book.
+     * The client must not already exist in the address book.
+     */
+    public void addClient(Client p) {
+        properties.add(p);
+    }
+
+    /**
+     * Replaces the given client {@code target} in the list with {@code editedClient}.
+     * {@code target} must exist in the address book.
+     * The client identity of {@code editedClient} must not be the same
+     * as another existing client in the address book.
+     */
+    public void setClient(Client target, Client editedClient) {
+        requireNonNull(editedClient);
+
+        properties.setClient(target, editedClient);
+    }
+
+    /**
+     * Removes {@code key} from this {@code ClientDirectory}.
+     * {@code key} must exist in the address book.
+     */
+    public void removeClient(Client key) {
+        properties.remove(key);
+    }
+
+    //// util methods
+
+    @Override
+    public String toString() {
+        return properties.asUnmodifiableObservableList().size() + " properties";
+        // TODO: refine later
+    }
+
+    @Override
+    public ObservableList<Client> getClientList() {
+        return properties.asUnmodifiableObservableList();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ClientDirectory // instanceof handles nulls
+                && properties.equals(((ClientDirectory) other).properties));
+    }
+
+    @Override
+    public int hashCode() {
+        return properties.hashCode();
+    }
+}

--- a/src/main/java/seedu/condonery/model/Model.java
+++ b/src/main/java/seedu/condonery/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.condonery.commons.core.GuiSettings;
+import seedu.condonery.model.client.Client;
 import seedu.condonery.model.property.Property;
 
 /**
@@ -13,6 +14,7 @@ import seedu.condonery.model.property.Property;
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Property> PREDICATE_SHOW_ALL_PROPERTIES = unused -> true;
+    Predicate<Client> PREDICATE_SHOW_ALL_CLIENTS = unused -> true;
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
@@ -85,4 +87,56 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPropertyList(Predicate<Property> predicate);
+
+    /**
+     * Returns the user prefs' client directory file path.
+     */
+    Path getClientDirectoryFilePath();
+
+    /**
+     * Sets the user prefs' client directory file path.
+     */
+    void setClientDirectoryFilePath(Path propertyDirectoryFilePath);
+
+    /**
+     * Replaces client directory data with the data in {@code clientDirectory}.
+     */
+    void setClientDirectory(ReadOnlyClientDirectory clientDirectory);
+
+    /** Returns the ClientDirectory */
+    ReadOnlyClientDirectory getClientDirectory();
+
+    /**
+     * Returns true if a client with the same identity as {@code client} exists in the client directory.
+     */
+    boolean hasClient(Client client);
+
+    /**
+     * Deletes the given client.
+     * The client must exist in the address book.
+     */
+    void deleteClient(Client target);
+
+    /**
+     * Adds the given client.
+     * {@code client} must not already exist in the client directory.
+     */
+    void addClient(Client client);
+
+    /**
+     * Replaces the given client {@code target} with {@code editedClient}.
+     * {@code target} must exist in the client directory.
+     * The client identity of {@code editedClient}
+     * must not be the same as another existing client in the address book.
+     */
+    void setClient(Client target, Client editedClient);
+
+    /** Returns an unmodifiable view of the filtered client list */
+    ObservableList<Client> getFilteredClientList();
+
+    /**
+     * Updates the filter of the filtered client list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredClientList(Predicate<Client> predicate);
 }

--- a/src/main/java/seedu/condonery/model/ModelManager.java
+++ b/src/main/java/seedu/condonery/model/ModelManager.java
@@ -11,6 +11,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.condonery.commons.core.GuiSettings;
 import seedu.condonery.commons.core.LogsCenter;
+import seedu.condonery.model.client.Client;
 import seedu.condonery.model.property.Property;
 
 /**
@@ -19,25 +20,31 @@ import seedu.condonery.model.property.Property;
 public class ModelManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
 
-    private final PropertyDirectory propertyDirectory;
     private final UserPrefs userPrefs;
+    private final PropertyDirectory propertyDirectory;
     private final FilteredList<Property> filteredProperties;
+    private final ClientDirectory clientDirectory;
+    private final FilteredList<Client> filteredClients;
 
     /**
      * Initializes a ModelManager with the given propertyDirectory and userPrefs.
      */
-    public ModelManager(ReadOnlyPropertyDirectory propertyDirectory, ReadOnlyUserPrefs userPrefs) {
-        requireAllNonNull(propertyDirectory, userPrefs);
+    public ModelManager(ReadOnlyPropertyDirectory propertyDirectory, ReadOnlyClientDirectory clientDirectory,
+                        ReadOnlyUserPrefs userPrefs) {
+        requireAllNonNull(propertyDirectory, clientDirectory, userPrefs);
 
         logger.fine("Initializing with address book: " + propertyDirectory + " and user prefs " + userPrefs);
 
         this.propertyDirectory = new PropertyDirectory(propertyDirectory);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredProperties = new FilteredList<>(this.propertyDirectory.getPropertyList());
+
+        this.clientDirectory = new ClientDirectory(clientDirectory);
+        filteredClients = new FilteredList<>(this.clientDirectory.getClientList());
     }
 
     public ModelManager() {
-        this(new PropertyDirectory(), new UserPrefs());
+        this(new PropertyDirectory(), new ClientDirectory(), new UserPrefs());
     }
 
     //=========== UserPrefs ==================================================================================
@@ -75,6 +82,17 @@ public class ModelManager implements Model {
         userPrefs.setPropertyDirectoryFilePath(propertyDirectoryFilePath);
     }
 
+    @Override
+    public Path getClientDirectoryFilePath() {
+        return userPrefs.getClientDirectoryFilePath();
+    }
+
+    @Override
+    public void setClientDirectoryFilePath(Path clientDirectoryFilePath) {
+        requireNonNull(clientDirectoryFilePath);
+        userPrefs.setClientDirectoryFilePath(clientDirectoryFilePath);
+    }
+
     //=========== PropertyDirectory ================================================================================
 
     @Override
@@ -88,6 +106,18 @@ public class ModelManager implements Model {
     }
 
     //=========== ClientDirectory ================================================================================
+
+    @Override
+    public void setClientDirectory(ReadOnlyClientDirectory clientDirectory) {
+        this.clientDirectory.resetData(clientDirectory);
+    }
+
+    @Override
+    public ReadOnlyClientDirectory getClientDirectory() {
+        return clientDirectory;
+    }
+
+    //=========== Property =======================================================================================
 
     @Override
     public boolean hasProperty(Property property) {
@@ -130,6 +160,48 @@ public class ModelManager implements Model {
         filteredProperties.setPredicate(predicate);
     }
 
+    //=========== Client ==========================================================================================
+
+    @Override
+    public boolean hasClient(Client client) {
+        requireNonNull(client);
+        return clientDirectory.hasClient(client);
+    }
+
+    @Override
+    public void deleteClient(Client target) {
+        clientDirectory.removeClient(target);
+    }
+
+    @Override
+    public void addClient(Client client) {
+        clientDirectory.addClient(client);
+        updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
+    }
+
+    @Override
+    public void setClient(Client target, Client editedClient) {
+        requireAllNonNull(target, editedClient);
+        clientDirectory.setClient(target, editedClient);
+    }
+
+    //=========== Filtered Client List Accessors =============================================================
+
+    /**
+     * Returns an unmodifiable view of the list of {@code Client} backed by the internal list of
+     * {@code versionedClientDirectory}
+     */
+    @Override
+    public ObservableList<Client> getFilteredClientList() {
+        return filteredClients;
+    }
+
+    @Override
+    public void updateFilteredClientList(Predicate<Client> predicate) {
+        requireNonNull(predicate);
+        filteredClients.setPredicate(predicate);
+    }
+
     @Override
     public boolean equals(Object obj) {
         // short circuit if same object
@@ -146,7 +218,9 @@ public class ModelManager implements Model {
         ModelManager other = (ModelManager) obj;
         return propertyDirectory.equals(other.propertyDirectory)
                 && userPrefs.equals(other.userPrefs)
-                && filteredProperties.equals(other.filteredProperties);
+                && filteredProperties.equals(other.filteredProperties)
+                && clientDirectory.equals(other.clientDirectory)
+                && filteredClients.equals(other.filteredClients);
     }
 
 }

--- a/src/main/java/seedu/condonery/model/ReadOnlyClientDirectory.java
+++ b/src/main/java/seedu/condonery/model/ReadOnlyClientDirectory.java
@@ -1,0 +1,17 @@
+package seedu.condonery.model;
+
+import javafx.collections.ObservableList;
+import seedu.condonery.model.client.Client;
+
+/**
+ * Unmodifiable view of an address book
+ */
+public interface ReadOnlyClientDirectory {
+
+    /**
+     * Returns an unmodifiable view of the properties list.
+     * This list will not contain any duplicate properties.
+     */
+    ObservableList<Client> getClientList();
+
+}

--- a/src/main/java/seedu/condonery/model/ReadOnlyUserPrefs.java
+++ b/src/main/java/seedu/condonery/model/ReadOnlyUserPrefs.java
@@ -13,4 +13,6 @@ public interface ReadOnlyUserPrefs {
 
     Path getPropertyDirectoryFilePath();
 
+    Path getClientDirectoryFilePath();
+
 }

--- a/src/main/java/seedu/condonery/model/UserPrefs.java
+++ b/src/main/java/seedu/condonery/model/UserPrefs.java
@@ -14,7 +14,8 @@ import seedu.condonery.commons.core.GuiSettings;
 public class UserPrefs implements ReadOnlyUserPrefs {
 
     private GuiSettings guiSettings = new GuiSettings();
-    private Path propertyDirectoryFilePath = Paths.get("data" , "addressbook.json");
+    private Path propertyDirectoryFilePath = Paths.get("data" , "propertyDirectory.json");
+    private Path clientDirectoryFilePath = Paths.get("data" , "clientDirectory.json");
 
     /**
      * Creates a {@code UserPrefs} with default values.
@@ -51,9 +52,18 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         return propertyDirectoryFilePath;
     }
 
+    public Path getClientDirectoryFilePath() {
+        return clientDirectoryFilePath;
+    }
+
     public void setPropertyDirectoryFilePath(Path propertyDirectoryFilePath) {
         requireNonNull(propertyDirectoryFilePath);
         this.propertyDirectoryFilePath = propertyDirectoryFilePath;
+    }
+
+    public void setClientDirectoryFilePath(Path clientDirectoryFilePath) {
+        requireNonNull(clientDirectoryFilePath);
+        this.clientDirectoryFilePath = clientDirectoryFilePath;
     }
 
     @Override

--- a/src/main/java/seedu/condonery/model/client/Address.java
+++ b/src/main/java/seedu/condonery/model/client/Address.java
@@ -1,0 +1,57 @@
+package seedu.condonery.model.client;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.condonery.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Property's address in Condonery.
+ * Guarantees: immutable; is valid as declared in {@link #isValidAddress(String)}
+ */
+public class Address {
+
+    public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values, and it should not be blank";
+
+    /*
+     * The first character of the address must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[^\\s].*";
+
+    public final String value;
+
+    /**
+     * Constructs an {@code Address}.
+     *
+     * @param address A valid address.
+     */
+    public Address(String address) {
+        requireNonNull(address);
+        checkArgument(isValidAddress(address), MESSAGE_CONSTRAINTS);
+        value = address;
+    }
+
+    /**
+     * Returns true if a given string is a valid email.
+     */
+    public static boolean isValidAddress(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Address // instanceof handles nulls
+                && value.equals(((Address) other).value)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/condonery/model/client/Client.java
+++ b/src/main/java/seedu/condonery/model/client/Client.java
@@ -7,8 +7,6 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
-import seedu.condonery.model.client.Address;
-import seedu.condonery.model.client.Name;
 import seedu.condonery.model.tag.Tag;
 
 /**

--- a/src/main/java/seedu/condonery/model/client/Client.java
+++ b/src/main/java/seedu/condonery/model/client/Client.java
@@ -1,0 +1,107 @@
+package seedu.condonery.model.client;
+
+import static seedu.condonery.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import seedu.condonery.model.client.Address;
+import seedu.condonery.model.client.Name;
+import seedu.condonery.model.tag.Tag;
+
+/**
+ * Represents a Client in Condonery.
+ * Guarantees: details are present and not null, field values are validated, immutable.
+ */
+public class Client {
+
+    // Identity fields
+    private final Name name;
+
+    // Data fields
+    private final Address address;
+    private final Set<Tag> tags = new HashSet<>();
+
+    /**
+     * Every field must be present and not null.
+     */
+    public Client(Name name, Address address, Set<Tag> tags) {
+        requireAllNonNull(name, address, tags);
+        this.name = name;
+        this.address = address;
+        this.tags.addAll(tags);
+    }
+
+    public Name getName() {
+        return name;
+    }
+
+    public Address getAddress() {
+        return address;
+    }
+
+    /**
+     * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
+     * if modification is attempted.
+     */
+    public Set<Tag> getTags() {
+        return Collections.unmodifiableSet(tags);
+    }
+
+    /**
+     * Returns true if both properties have the same name.
+     * This defines a weaker notion of equality between two properties.
+     */
+    public boolean isSameClient(Client otherClient) {
+        if (otherClient == this) {
+            return true;
+        }
+
+        return otherClient != null
+                && otherClient.getName().equals(getName());
+    }
+
+    /**
+     * Returns true if both properties have the same identity and data fields.
+     * This defines a stronger notion of equality between two properties.
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof Client)) {
+            return false;
+        }
+
+        Client otherClient = (Client) other;
+        return otherClient.getName().equals(getName())
+            && otherClient.getAddress().equals(getAddress())
+            && otherClient.getTags().equals(getTags());
+    }
+
+    @Override
+    public int hashCode() {
+        // use this method for custom fields hashing instead of implementing your own
+        return Objects.hash(name, address, tags);
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append(getName())
+            .append("; Address: ")
+            .append(getAddress());
+
+        Set<Tag> tags = getTags();
+        if (!tags.isEmpty()) {
+            builder.append("; Tags: ");
+            tags.forEach(builder::append);
+        }
+        return builder.toString();
+    }
+}
+

--- a/src/main/java/seedu/condonery/model/client/Name.java
+++ b/src/main/java/seedu/condonery/model/client/Name.java
@@ -1,0 +1,59 @@
+package seedu.condonery.model.client;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.condonery.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Property's name in Condonery.
+ * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
+ */
+public class Name {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Names can take any values, and it should not be blank";
+
+    /*
+     * The first character of the address must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[^\\s].*";
+
+    public final String fullName;
+
+    /**
+     * Constructs a {@code Name}.
+     *
+     * @param name A valid name.
+     */
+    public Name(String name) {
+        requireNonNull(name);
+        checkArgument(isValidName(name), MESSAGE_CONSTRAINTS);
+        fullName = name;
+    }
+
+    /**
+     * Returns true if a given string is a valid name.
+     */
+    public static boolean isValidName(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+
+    @Override
+    public String toString() {
+        return fullName;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Name // instanceof handles nulls
+                && fullName.equals(((Name) other).fullName)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return fullName.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/condonery/model/client/UniqueClientList.java
+++ b/src/main/java/seedu/condonery/model/client/UniqueClientList.java
@@ -1,0 +1,138 @@
+package seedu.condonery.model.client;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.condonery.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Iterator;
+import java.util.List;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.condonery.model.client.exceptions.ClientNotFoundException;
+import seedu.condonery.model.client.exceptions.DuplicateClientException;
+
+/**
+ * A list of properties that enforces uniqueness between its elements and does not allow nulls.
+ * A client is considered unique by comparing using {@code Client#isSameClient(Client)}.
+ * As such, adding and updating of properties uses Client#isSameClient(Client) for equality
+ * so as to ensure that the client being added or updated is unique in terms of identity in the
+ * UniqueClientList. However, the removal of a client uses Client#equals(Object) so
+ * as to ensure that the client with exactly the same fields will be removed.
+ *
+ * Supports a minimal set of list operations.
+ *
+ * @see Client#isSameClient(Client)
+ */
+public class UniqueClientList implements Iterable<Client> {
+
+    private final ObservableList<Client> internalList = FXCollections.observableArrayList();
+    private final ObservableList<Client> internalUnmodifiableList =
+            FXCollections.unmodifiableObservableList(internalList);
+
+    /**
+     * Returns true if the list contains an equivalent client as the given argument.
+     */
+    public boolean contains(Client toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::isSameClient);
+    }
+
+    /**
+     * Adds a client to the list.
+     * The client must not already exist in the list.
+     */
+    public void add(Client toAdd) {
+        requireNonNull(toAdd);
+        if (contains(toAdd)) {
+            throw new DuplicateClientException();
+        }
+        internalList.add(toAdd);
+    }
+
+    /**
+     * Replaces the client {@code target} in the list with {@code editedClient}.
+     * {@code target} must exist in the list.
+     * The client identity of {@code editedClient} must not be the same as another existing client in the list.
+     */
+    public void setClient(Client target, Client editedClient) {
+        requireAllNonNull(target, editedClient);
+
+        int index = internalList.indexOf(target);
+        if (index == -1) {
+            throw new ClientNotFoundException();
+        }
+
+        if (!target.isSameClient(editedClient) && contains(editedClient)) {
+            throw new DuplicateClientException();
+        }
+
+        internalList.set(index, editedClient);
+    }
+
+    /**
+     * Removes the equivalent client from the list.
+     * The client must exist in the list.
+     */
+    public void remove(Client toRemove) {
+        requireNonNull(toRemove);
+        if (!internalList.remove(toRemove)) {
+            throw new ClientNotFoundException();
+        }
+    }
+
+    public void setClients(UniqueClientList replacement) {
+        requireNonNull(replacement);
+        internalList.setAll(replacement.internalList);
+    }
+
+    /**
+     * Replaces the contents of this list with {@code properties}.
+     * {@code properties} must not contain duplicate properties.
+     */
+    public void setClients(List<Client> clients) {
+        requireAllNonNull(clients);
+        if (!clientsAreUnique(clients)) {
+            throw new DuplicateClientException();
+        }
+
+        internalList.setAll(clients);
+    }
+
+    /**
+     * Returns the backing list as an unmodifiable {@code ObservableList}.
+     */
+    public ObservableList<Client> asUnmodifiableObservableList() {
+        return internalUnmodifiableList;
+    }
+
+    @Override
+    public Iterator<Client> iterator() {
+        return internalList.iterator();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof UniqueClientList // instanceof handles nulls
+                        && internalList.equals(((UniqueClientList) other).internalList));
+    }
+
+    @Override
+    public int hashCode() {
+        return internalList.hashCode();
+    }
+
+    /**
+     * Returns true if {@code properties} contains only unique properties.
+     */
+    private boolean clientsAreUnique(List<Client> clients) {
+        for (int i = 0; i < clients.size() - 1; i++) {
+            for (int j = i + 1; j < clients.size(); j++) {
+                if (clients.get(i).isSameClient(clients.get(j))) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/seedu/condonery/model/client/exceptions/ClientNotFoundException.java
+++ b/src/main/java/seedu/condonery/model/client/exceptions/ClientNotFoundException.java
@@ -1,0 +1,6 @@
+package seedu.condonery.model.client.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified property.
+ */
+public class ClientNotFoundException extends RuntimeException {}

--- a/src/main/java/seedu/condonery/model/client/exceptions/DuplicateClientException.java
+++ b/src/main/java/seedu/condonery/model/client/exceptions/DuplicateClientException.java
@@ -1,0 +1,11 @@
+package seedu.condonery.model.client.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Properties (Properties are considered duplicates
+ * if they have the same identity).
+ */
+public class DuplicateClientException extends RuntimeException {
+    public DuplicateClientException() {
+        super("Operation would result in duplicate properties");
+    }
+}

--- a/src/main/java/seedu/condonery/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/condonery/model/util/SampleDataUtil.java
@@ -4,8 +4,11 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import seedu.condonery.model.ClientDirectory;
 import seedu.condonery.model.PropertyDirectory;
+import seedu.condonery.model.ReadOnlyClientDirectory;
 import seedu.condonery.model.ReadOnlyPropertyDirectory;
+import seedu.condonery.model.client.Client;
 import seedu.condonery.model.property.Address;
 import seedu.condonery.model.property.Name;
 import seedu.condonery.model.property.Property;
@@ -26,12 +29,26 @@ public class SampleDataUtil {
         };
     }
 
+    public static Client[] getSampleClients() {
+        // TODO: add sample client data
+        return new Client[] {
+        };
+    }
+
     public static ReadOnlyPropertyDirectory getSamplePropertyDirectory() {
         PropertyDirectory sampleAb = new PropertyDirectory();
         for (Property sampleProperty : getSampleProperties()) {
             sampleAb.addProperty(sampleProperty);
         }
         return sampleAb;
+    }
+
+    public static ReadOnlyClientDirectory getSampleClientDirectory() {
+        ClientDirectory sampleCd = new ClientDirectory();
+        for (Client sampleClient : getSampleClients()) {
+            sampleCd.addClient(sampleClient);
+        }
+        return sampleCd;
     }
 
     /**

--- a/src/main/java/seedu/condonery/storage/ClientDirectoryStorage.java
+++ b/src/main/java/seedu/condonery/storage/ClientDirectoryStorage.java
@@ -1,11 +1,11 @@
 package seedu.condonery.storage;
 
-import seedu.condonery.commons.exceptions.DataConversionException;
-import seedu.condonery.model.ReadOnlyClientDirectory;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
+
+import seedu.condonery.commons.exceptions.DataConversionException;
+import seedu.condonery.model.ReadOnlyClientDirectory;
 
 /**
  * Represents a storage for {@link seedu.condonery.model.ClientDirectory}.

--- a/src/main/java/seedu/condonery/storage/ClientDirectoryStorage.java
+++ b/src/main/java/seedu/condonery/storage/ClientDirectoryStorage.java
@@ -1,0 +1,46 @@
+package seedu.condonery.storage;
+
+import seedu.condonery.commons.exceptions.DataConversionException;
+import seedu.condonery.model.ReadOnlyClientDirectory;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * Represents a storage for {@link seedu.condonery.model.ClientDirectory}.
+ */
+public interface ClientDirectoryStorage {
+
+    /**
+     * Returns the file path of the data file.
+     */
+    Path getClientDirectoryFilePath();
+
+    /**
+     * Returns ClientDirectory data as a {@link ReadOnlyClientDirectory}.
+     *   Returns {@code Optional.empty()} if storage file is not found.
+     * @throws DataConversionException if the data in storage is not in the expected format.
+     * @throws IOException if there was any problem when reading from the storage.
+     */
+    Optional<ReadOnlyClientDirectory> readClientDirectory() throws DataConversionException, IOException;
+
+    /**
+     * @see #getClientDirectoryFilePath()
+     */
+    Optional<ReadOnlyClientDirectory> readClientDirectory(Path filePath)
+            throws DataConversionException, IOException;
+
+    /**
+     * Saves the given {@link ReadOnlyClientDirectory} to the storage.
+     * @param clientDirectory cannot be null.
+     * @throws IOException if there was any problem writing to the file.
+     */
+    void saveClientDirectory(ReadOnlyClientDirectory clientDirectory) throws IOException;
+
+    /**
+     * @see #saveClientDirectory(ReadOnlyClientDirectory)
+     */
+    void saveClientDirectory(ReadOnlyClientDirectory clientDirectory, Path filePath) throws IOException;
+
+}

--- a/src/main/java/seedu/condonery/storage/JsonAdaptedClient.java
+++ b/src/main/java/seedu/condonery/storage/JsonAdaptedClient.java
@@ -1,18 +1,19 @@
 package seedu.condonery.storage;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import seedu.condonery.commons.exceptions.IllegalValueException;
-import seedu.condonery.model.client.Address;
-import seedu.condonery.model.client.Name;
-import seedu.condonery.model.client.Client;
-import seedu.condonery.model.tag.Tag;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.condonery.commons.exceptions.IllegalValueException;
+import seedu.condonery.model.client.Address;
+import seedu.condonery.model.client.Client;
+import seedu.condonery.model.client.Name;
+import seedu.condonery.model.tag.Tag;
 
 /**
  * Jackson-friendly version of {@link Client}.

--- a/src/main/java/seedu/condonery/storage/JsonAdaptedClient.java
+++ b/src/main/java/seedu/condonery/storage/JsonAdaptedClient.java
@@ -1,0 +1,83 @@
+package seedu.condonery.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import seedu.condonery.commons.exceptions.IllegalValueException;
+import seedu.condonery.model.client.Address;
+import seedu.condonery.model.client.Name;
+import seedu.condonery.model.client.Client;
+import seedu.condonery.model.tag.Tag;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Jackson-friendly version of {@link Client}.
+ */
+class JsonAdaptedClient {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Client's %s field is missing!";
+
+    private final String name;
+    private final String address;
+    private final List<JsonAdaptedTag> tagged = new ArrayList<>();
+
+    /**
+     * Constructs a {@code JsonAdaptedClient} with the given client details.
+     */
+    @JsonCreator
+    public JsonAdaptedClient(@JsonProperty("name") String name, @JsonProperty("address") String address,
+                             @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+        this.name = name;
+        this.address = address;
+        if (tagged != null) {
+            this.tagged.addAll(tagged);
+        }
+    }
+
+    /**
+     * Converts a given {@code Client} into this class for Jackson use.
+     */
+    public JsonAdaptedClient(Client source) {
+        name = source.getName().fullName;
+        address = source.getAddress().value;
+        tagged.addAll(source.getTags().stream()
+                .map(JsonAdaptedTag::new)
+                .collect(Collectors.toList()));
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted client object into the model's {@code Client} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted client.
+     */
+    public Client toModelType() throws IllegalValueException {
+        final List<Tag> clientTags = new ArrayList<>();
+        for (JsonAdaptedTag tag : tagged) {
+            clientTags.add(tag.toModelType());
+        }
+
+        if (name == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
+        }
+        if (!Name.isValidName(name)) {
+            throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS);
+        }
+        final Name modelName = new Name(name);
+
+        if (address == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName()));
+        }
+        if (!Address.isValidAddress(address)) {
+            throw new IllegalValueException(Address.MESSAGE_CONSTRAINTS);
+        }
+        final Address modelAddress = new Address(address);
+
+        final Set<Tag> modelTags = new HashSet<>(clientTags);
+        return new Client(modelName, modelAddress, modelTags);
+    }
+
+}

--- a/src/main/java/seedu/condonery/storage/JsonClientDirectoryStorage.java
+++ b/src/main/java/seedu/condonery/storage/JsonClientDirectoryStorage.java
@@ -1,18 +1,18 @@
 package seedu.condonery.storage;
 
-import seedu.condonery.commons.core.LogsCenter;
-import seedu.condonery.commons.exceptions.DataConversionException;
-import seedu.condonery.commons.exceptions.IllegalValueException;
-import seedu.condonery.commons.util.FileUtil;
-import seedu.condonery.commons.util.JsonUtil;
-import seedu.condonery.model.ReadOnlyClientDirectory;
+import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.logging.Logger;
 
-import static java.util.Objects.requireNonNull;
+import seedu.condonery.commons.core.LogsCenter;
+import seedu.condonery.commons.exceptions.DataConversionException;
+import seedu.condonery.commons.exceptions.IllegalValueException;
+import seedu.condonery.commons.util.FileUtil;
+import seedu.condonery.commons.util.JsonUtil;
+import seedu.condonery.model.ReadOnlyClientDirectory;
 
 /**
  * A class to access ClientDirectory data stored as a json file on the hard disk.

--- a/src/main/java/seedu/condonery/storage/JsonClientDirectoryStorage.java
+++ b/src/main/java/seedu/condonery/storage/JsonClientDirectoryStorage.java
@@ -1,0 +1,80 @@
+package seedu.condonery.storage;
+
+import seedu.condonery.commons.core.LogsCenter;
+import seedu.condonery.commons.exceptions.DataConversionException;
+import seedu.condonery.commons.exceptions.IllegalValueException;
+import seedu.condonery.commons.util.FileUtil;
+import seedu.condonery.commons.util.JsonUtil;
+import seedu.condonery.model.ReadOnlyClientDirectory;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A class to access ClientDirectory data stored as a json file on the hard disk.
+ */
+public class JsonClientDirectoryStorage implements ClientDirectoryStorage {
+
+    private static final Logger logger = LogsCenter.getLogger(JsonClientDirectoryStorage.class);
+
+    private Path filePath;
+
+    public JsonClientDirectoryStorage(Path filePath) {
+        this.filePath = filePath;
+    }
+
+    public Path getClientDirectoryFilePath() {
+        return filePath;
+    }
+
+    @Override
+    public Optional<ReadOnlyClientDirectory> readClientDirectory() throws DataConversionException {
+        return readClientDirectory(filePath);
+    }
+
+    /**
+     * Similar to {@link #readClientDirectory()}.
+     *
+     * @param filePath location of the data. Cannot be null.
+     * @throws DataConversionException if the file is not in the correct format.
+     */
+    public Optional<ReadOnlyClientDirectory> readClientDirectory(Path filePath) throws DataConversionException {
+        requireNonNull(filePath);
+
+        Optional<JsonSerializableClientDirectory> jsonClientDirectory = JsonUtil.readJsonFile(
+                filePath, JsonSerializableClientDirectory.class);
+        if (!jsonClientDirectory.isPresent()) {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(jsonClientDirectory.get().toModelType());
+        } catch (IllegalValueException ive) {
+            logger.info("Illegal values found in " + filePath + ": " + ive.getMessage());
+            throw new DataConversionException(ive);
+        }
+    }
+
+    @Override
+    public void saveClientDirectory(ReadOnlyClientDirectory clientDirectory) throws IOException {
+        saveClientDirectory(clientDirectory, filePath);
+    }
+
+    /**
+     * Similar to {@link #saveClientDirectory(ReadOnlyClientDirectory)}.
+     *
+     * @param filePath location of the data. Cannot be null.
+     */
+    public void saveClientDirectory(ReadOnlyClientDirectory clientDirectory, Path filePath) throws IOException {
+        requireNonNull(clientDirectory);
+        requireNonNull(filePath);
+
+        FileUtil.createIfMissing(filePath);
+        JsonUtil.saveJsonFile(new JsonSerializableClientDirectory(clientDirectory), filePath);
+    }
+
+}

--- a/src/main/java/seedu/condonery/storage/JsonSerializableClientDirectory.java
+++ b/src/main/java/seedu/condonery/storage/JsonSerializableClientDirectory.java
@@ -1,0 +1,60 @@
+package seedu.condonery.storage;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+import seedu.condonery.commons.exceptions.IllegalValueException;
+import seedu.condonery.model.ClientDirectory;
+import seedu.condonery.model.ReadOnlyClientDirectory;
+import seedu.condonery.model.client.Client;
+
+/**
+ * An Immutable ClientDirectory that is serializable to JSON format.
+ */
+@JsonRootName(value = "clientDirectory")
+class JsonSerializableClientDirectory {
+
+    public static final String MESSAGE_DUPLICATE_PROPERTY = "Properties list contains duplicate client(s).";
+
+    private final List<JsonAdaptedClient> clients = new ArrayList<>();
+
+    /**
+     * Constructs a {@code JsonSerializableClientDirectory} with the given clients.
+     */
+    @JsonCreator
+    public JsonSerializableClientDirectory(@JsonProperty("clients") List<JsonAdaptedClient> clients) {
+        this.clients.addAll(clients);
+    }
+
+    /**
+     * Converts a given {@code ReadOnlyClientDirectory} into this class for Jackson use.
+     *
+     * @param source future changes to this will not affect the created {@code JsonSerializableClientDirectory}.
+     */
+    public JsonSerializableClientDirectory(ReadOnlyClientDirectory source) {
+        clients.addAll(source.getClientList().stream().map(JsonAdaptedClient::new).collect(Collectors.toList()));
+    }
+
+    /**
+     * Converts this address book into the model's {@code ClientDirectory} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated.
+     */
+    public ClientDirectory toModelType() throws IllegalValueException {
+        ClientDirectory clientDirectory = new ClientDirectory();
+        for (JsonAdaptedClient jsonAdaptedClient : clients) {
+            Client client = jsonAdaptedClient.toModelType();
+            if (clientDirectory.hasClient(client)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_PROPERTY);
+            }
+            clientDirectory.addClient(client);
+        }
+        return clientDirectory;
+    }
+
+}

--- a/src/main/java/seedu/condonery/storage/JsonSerializablePropertyDirectory.java
+++ b/src/main/java/seedu/condonery/storage/JsonSerializablePropertyDirectory.java
@@ -16,7 +16,7 @@ import seedu.condonery.model.property.Property;
 /**
  * An Immutable PropertyDirectory that is serializable to JSON format.
  */
-@JsonRootName(value = "addressbook")
+@JsonRootName(value = "propertyDirectory")
 class JsonSerializablePropertyDirectory {
 
     public static final String MESSAGE_DUPLICATE_PROPERTY = "Properties list contains duplicate property(s).";

--- a/src/main/java/seedu/condonery/storage/Storage.java
+++ b/src/main/java/seedu/condonery/storage/Storage.java
@@ -5,14 +5,12 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 import seedu.condonery.commons.exceptions.DataConversionException;
-import seedu.condonery.model.ReadOnlyPropertyDirectory;
-import seedu.condonery.model.ReadOnlyUserPrefs;
-import seedu.condonery.model.UserPrefs;
+import seedu.condonery.model.*;
 
 /**
  * API of the Storage component
  */
-public interface Storage extends PropertyDirectoryStorage, UserPrefsStorage {
+public interface Storage extends PropertyDirectoryStorage, ClientDirectoryStorage, UserPrefsStorage {
 
     @Override
     Optional<UserPrefs> readUserPrefs() throws DataConversionException, IOException;
@@ -28,5 +26,14 @@ public interface Storage extends PropertyDirectoryStorage, UserPrefsStorage {
 
     @Override
     void savePropertyDirectory(ReadOnlyPropertyDirectory propertyDirectory) throws IOException;
+
+    @Override
+    Path getClientDirectoryFilePath();
+
+    @Override
+    Optional<ReadOnlyClientDirectory> readClientDirectory() throws DataConversionException, IOException;
+
+    @Override
+    void saveClientDirectory(ReadOnlyClientDirectory clientDirectory) throws IOException;
 
 }

--- a/src/main/java/seedu/condonery/storage/Storage.java
+++ b/src/main/java/seedu/condonery/storage/Storage.java
@@ -5,7 +5,10 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 import seedu.condonery.commons.exceptions.DataConversionException;
-import seedu.condonery.model.*;
+import seedu.condonery.model.ReadOnlyClientDirectory;
+import seedu.condonery.model.ReadOnlyPropertyDirectory;
+import seedu.condonery.model.ReadOnlyUserPrefs;
+import seedu.condonery.model.UserPrefs;
 
 /**
  * API of the Storage component

--- a/src/main/java/seedu/condonery/storage/StorageManager.java
+++ b/src/main/java/seedu/condonery/storage/StorageManager.java
@@ -7,7 +7,10 @@ import java.util.logging.Logger;
 
 import seedu.condonery.commons.core.LogsCenter;
 import seedu.condonery.commons.exceptions.DataConversionException;
-import seedu.condonery.model.*;
+import seedu.condonery.model.ReadOnlyClientDirectory;
+import seedu.condonery.model.ReadOnlyPropertyDirectory;
+import seedu.condonery.model.ReadOnlyUserPrefs;
+import seedu.condonery.model.UserPrefs;
 
 /**
  * Manages storage of PropertyDirectory data in local storage.

--- a/src/main/java/seedu/condonery/storage/StorageManager.java
+++ b/src/main/java/seedu/condonery/storage/StorageManager.java
@@ -7,9 +7,7 @@ import java.util.logging.Logger;
 
 import seedu.condonery.commons.core.LogsCenter;
 import seedu.condonery.commons.exceptions.DataConversionException;
-import seedu.condonery.model.ReadOnlyPropertyDirectory;
-import seedu.condonery.model.ReadOnlyUserPrefs;
-import seedu.condonery.model.UserPrefs;
+import seedu.condonery.model.*;
 
 /**
  * Manages storage of PropertyDirectory data in local storage.
@@ -17,13 +15,16 @@ import seedu.condonery.model.UserPrefs;
 public class StorageManager implements Storage {
 
     private static final Logger logger = LogsCenter.getLogger(StorageManager.class);
+    private ClientDirectoryStorage clientDirectoryStorage;
     private PropertyDirectoryStorage propertyDirectoryStorage;
     private UserPrefsStorage userPrefsStorage;
 
     /**
      * Creates a {@code StorageManager} with the given {@code PropertyDirectoryStorage} and {@code UserPrefStorage}.
      */
-    public StorageManager(PropertyDirectoryStorage propertyDirectoryStorage, UserPrefsStorage userPrefsStorage) {
+    public StorageManager(PropertyDirectoryStorage propertyDirectoryStorage,
+                          ClientDirectoryStorage clientDirectoryStorage, UserPrefsStorage userPrefsStorage) {
+        this.clientDirectoryStorage = clientDirectoryStorage;
         this.propertyDirectoryStorage = propertyDirectoryStorage;
         this.userPrefsStorage = userPrefsStorage;
     }
@@ -76,4 +77,33 @@ public class StorageManager implements Storage {
         propertyDirectoryStorage.savePropertyDirectory(propertyDirectory, filePath);
     }
 
+    // ================ ClientDirectory methods ==============================
+
+    @Override
+    public Path getClientDirectoryFilePath() {
+        return clientDirectoryStorage.getClientDirectoryFilePath();
+    }
+
+    @Override
+    public Optional<ReadOnlyClientDirectory> readClientDirectory() throws DataConversionException, IOException {
+        return readClientDirectory(clientDirectoryStorage.getClientDirectoryFilePath());
+    }
+
+    @Override
+    public Optional<ReadOnlyClientDirectory> readClientDirectory(Path filePath)
+            throws DataConversionException, IOException {
+        logger.fine("Attempting to read data from file: " + filePath);
+        return clientDirectoryStorage.readClientDirectory(filePath);
+    }
+
+    @Override
+    public void saveClientDirectory(ReadOnlyClientDirectory clientDirectory) throws IOException {
+        saveClientDirectory(clientDirectory, clientDirectoryStorage.getClientDirectoryFilePath());
+    }
+
+    @Override
+    public void saveClientDirectory(ReadOnlyClientDirectory clientDirectory, Path filePath) throws IOException {
+        logger.fine("Attempting to write to data file: " + filePath);
+        clientDirectoryStorage.saveClientDirectory(clientDirectory, filePath);
+    }
 }

--- a/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
@@ -9,5 +9,6 @@
       "z": 99
     }
   },
-  "propertyDirectoryFilePath": "addressbook.json"
+  "propertyDirectoryFilePath": "propertyDirectory.json",
+  "clientDirectoryFilePath": "clientDirectory.json"
 }

--- a/src/test/data/JsonUserPrefsStorageTest/TypicalUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/TypicalUserPref.json
@@ -7,5 +7,6 @@
       "y": 100
     }
   },
-  "propertyDirectoryFilePath": "addressbook.json"
+  "propertyDirectoryFilePath": "propertyDirectory.json",
+  "clientDirectoryFilePath": "clientDirectory.json"
 }

--- a/src/test/java/seedu/condonery/storage/JsonUserPrefsStorageTest.java
+++ b/src/test/java/seedu/condonery/storage/JsonUserPrefsStorageTest.java
@@ -73,7 +73,7 @@ public class JsonUserPrefsStorageTest {
     private UserPrefs getTypicalUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
         userPrefs.setGuiSettings(new GuiSettings(1000, 500, 300, 100));
-        userPrefs.setPropertyDirectoryFilePath(Paths.get("addressbook.json"));
+        userPrefs.setPropertyDirectoryFilePath(Paths.get("propertyDirectory.json"));
         return userPrefs;
     }
 


### PR DESCRIPTION
This PR add a separate ClientDirectory and the corresponding Client Models, to prepare us for adding Client commands.

As of right now, I separated both clientDirectory and propertyDirectory, with 2 separate file storages. In the future, we might want to think about whether we can inherit both Directories from a parent abstract class, but might not be overly important.

I have yet to write my JUnit tests.

Breaking Changes:
1. Need to add the lines in `preferences.json`
```json
{
  "guiSettings" : {
    "windowWidth" : 1522.0,
    "windowHeight" : 638.0,
    "windowCoordinates" : {
      "x" : 87,
      "y" : 31
    }
  },
  "propertyDirectoryFilePath" : "data/propertyDirectory.json",
  "clientDirectoryFilePath" : "data/clientDirectory.json"
}
```