### PR TITLE
Handle negative input for range commands

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -305,7 +305,11 @@ Format: `list -c`
 ### Filtering client profiles: `filter -c`
 
 Returns a filtered list of clients according to specified tags.
+
+TAG have to be fully specified (i.e. no partial tags like 'high' instead of 'high-end')
+
 Format: `filter -c TAG...`
+
 Examples:
 * `filter -c high-end`
 * `filter -c thrifty`

--- a/src/main/java/seedu/condonery/commons/core/Messages.java
+++ b/src/main/java/seedu/condonery/commons/core/Messages.java
@@ -13,7 +13,7 @@ public class Messages {
     public static final String MESSAGE_CLIENTS_LISTED_OVERVIEW = "%1$d clients listed!";
     public static final String MESSAGE_INVALID_STATUS =
             "Only AVAILABLE, PENDING, SOLD status is accepted (Case sensitive)";
-    public static final String MESSAGE_NUMBER_INVALID = "%1$d clients listed!";
+    public static final String MESSAGE_NUMBER_INVALID = "Invalid number! Please enter a valid positive integer value";
     public static final String MESSAGE_RANGE_INVALID =
             "Invalid range listed! Upper range must be higher than lower range";
     public static final String MESSAGE_NEGATIVE_NUMBER = "Only positive numbers are accepted!";

--- a/src/main/java/seedu/condonery/commons/core/Messages.java
+++ b/src/main/java/seedu/condonery/commons/core/Messages.java
@@ -13,5 +13,10 @@ public class Messages {
     public static final String MESSAGE_CLIENTS_LISTED_OVERVIEW = "%1$d clients listed!";
     public static final String MESSAGE_INVALID_STATUS =
             "Only AVAILABLE, PENDING, SOLD status is accepted (Case sensitive)";
+    public static final String MESSAGE_NUMBER_INVALID = "%1$d clients listed!";
+    public static final String MESSAGE_RANGE_INVALID =
+            "Invalid range listed! Upper range must be higher than lower range";
+    public static final String MESSAGE_NEGATIVE_NUMBER = "Only positive numbers are accepted!";
+
 
 }

--- a/src/main/java/seedu/condonery/logic/parser/property/RangePropertyCommandParser.java
+++ b/src/main/java/seedu/condonery/logic/parser/property/RangePropertyCommandParser.java
@@ -2,6 +2,7 @@ package seedu.condonery.logic.parser.property;
 
 import static seedu.condonery.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.condonery.commons.core.Messages.MESSAGE_NEGATIVE_NUMBER;
+import static seedu.condonery.commons.core.Messages.MESSAGE_NUMBER_INVALID;
 import static seedu.condonery.commons.core.Messages.MESSAGE_RANGE_INVALID;
 import static seedu.condonery.logic.parser.CliSyntax.PREFIX_LOWER;
 import static seedu.condonery.logic.parser.CliSyntax.PREFIX_UPPER;
@@ -35,6 +36,13 @@ public class RangePropertyCommandParser implements Parser<Command> {
         if (!arePrefixesPresent(argMultimap, PREFIX_LOWER, PREFIX_UPPER)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RangePropertyCommand.MESSAGE_USAGE));
+        }
+
+        try {
+            ParserUtil.parseNumber(argMultimap.getValue(PREFIX_LOWER).get());
+            ParserUtil.parseNumber(argMultimap.getValue(PREFIX_UPPER).get());
+        } catch (NumberFormatException e) {
+            throw new ParseException(String.format(MESSAGE_NUMBER_INVALID, RangePropertyCommand.MESSAGE_USAGE));
         }
         Integer lower = ParserUtil.parseNumber(argMultimap.getValue(PREFIX_LOWER).get());
         Integer upper = ParserUtil.parseNumber(argMultimap.getValue(PREFIX_UPPER).get());

--- a/src/main/java/seedu/condonery/logic/parser/property/RangePropertyCommandParser.java
+++ b/src/main/java/seedu/condonery/logic/parser/property/RangePropertyCommandParser.java
@@ -1,6 +1,8 @@
 package seedu.condonery.logic.parser.property;
 
 import static seedu.condonery.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.condonery.commons.core.Messages.MESSAGE_NEGATIVE_NUMBER;
+import static seedu.condonery.commons.core.Messages.MESSAGE_RANGE_INVALID;
 import static seedu.condonery.logic.parser.CliSyntax.PREFIX_LOWER;
 import static seedu.condonery.logic.parser.CliSyntax.PREFIX_UPPER;
 
@@ -34,11 +36,18 @@ public class RangePropertyCommandParser implements Parser<Command> {
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RangePropertyCommand.MESSAGE_USAGE));
         }
-
         Integer lower = ParserUtil.parseNumber(argMultimap.getValue(PREFIX_LOWER).get());
         Integer upper = ParserUtil.parseNumber(argMultimap.getValue(PREFIX_UPPER).get());
 
+        if (lower > upper) {
+            throw new ParseException(String.format(MESSAGE_RANGE_INVALID, RangePropertyCommand.MESSAGE_USAGE));
+        }
+
+        if (Integer.signum(lower) == -1 || Integer.signum(upper) == -1) {
+            throw new ParseException(String.format(MESSAGE_NEGATIVE_NUMBER, RangePropertyCommand.MESSAGE_USAGE));
+        }
         return new RangePropertyCommand(new PropertyPriceWithinRangePredicate(lower, upper));
+
     }
 
     /**

--- a/src/test/java/seedu/condonery/logic/parser/property/RangePropertyCommandParserTest.java
+++ b/src/test/java/seedu/condonery/logic/parser/property/RangePropertyCommandParserTest.java
@@ -1,0 +1,47 @@
+package seedu.condonery.logic.parser.property;
+
+import static seedu.condonery.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.condonery.commons.core.Messages.MESSAGE_NEGATIVE_NUMBER;
+import static seedu.condonery.commons.core.Messages.MESSAGE_RANGE_INVALID;
+import static seedu.condonery.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.condonery.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.condonery.logic.commands.property.RangePropertyCommand;
+import seedu.condonery.model.property.PropertyPriceWithinRangePredicate;
+
+public class RangePropertyCommandParserTest {
+    private final RangePropertyCommandParser parser = new RangePropertyCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                RangePropertyCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validRangeCommand() {
+        PropertyPriceWithinRangePredicate predicate = new PropertyPriceWithinRangePredicate(90000, 180000);
+        assertParseSuccess(parser, " l/90000 u/180000", new RangePropertyCommand(predicate));
+    }
+
+    @Test
+    public void parse_lowerMoreThanUpper() {
+        assertParseFailure(parser, " l/80000 u/70000", String.format(MESSAGE_RANGE_INVALID,
+                RangePropertyCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_negativeInLower() {
+        assertParseFailure(parser, " l/-80000 u/70000", String.format(MESSAGE_NEGATIVE_NUMBER,
+                RangePropertyCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_negativeInLowerAndUpper() {
+        assertParseFailure(parser, " l/-80000 u/-70000", String.format(MESSAGE_NEGATIVE_NUMBER,
+                RangePropertyCommand.MESSAGE_USAGE));
+    }
+
+}

--- a/src/test/java/seedu/condonery/logic/parser/property/RangePropertyCommandParserTest.java
+++ b/src/test/java/seedu/condonery/logic/parser/property/RangePropertyCommandParserTest.java
@@ -2,6 +2,7 @@ package seedu.condonery.logic.parser.property;
 
 import static seedu.condonery.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.condonery.commons.core.Messages.MESSAGE_NEGATIVE_NUMBER;
+import static seedu.condonery.commons.core.Messages.MESSAGE_NUMBER_INVALID;
 import static seedu.condonery.commons.core.Messages.MESSAGE_RANGE_INVALID;
 import static seedu.condonery.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.condonery.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -41,6 +42,18 @@ public class RangePropertyCommandParserTest {
     @Test
     public void parse_negativeInLowerAndUpper() {
         assertParseFailure(parser, " l/-80000 u/-70000", String.format(MESSAGE_NEGATIVE_NUMBER,
+                RangePropertyCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_lowerGivenStringInsteadOfNumber() {
+        assertParseFailure(parser, " l/-asdasd u/70000", String.format(MESSAGE_NUMBER_INVALID,
+                RangePropertyCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_upperGivenStringInsteadOfNumber() {
+        assertParseFailure(parser, " l/90000 u/-asdasd", String.format(MESSAGE_NUMBER_INVALID,
                 RangePropertyCommand.MESSAGE_USAGE));
     }
 

--- a/src/test/java/seedu/condonery/logic/parser/property/RangePropertyCommandParserTest.java
+++ b/src/test/java/seedu/condonery/logic/parser/property/RangePropertyCommandParserTest.java
@@ -57,4 +57,10 @@ public class RangePropertyCommandParserTest {
                 RangePropertyCommand.MESSAGE_USAGE));
     }
 
+    @Test
+    public void parse_upperGivenSymbolsInsteadOfNumber() {
+        assertParseFailure(parser, " l/90000 u/-,,,,,", String.format(MESSAGE_NUMBER_INVALID,
+                RangePropertyCommand.MESSAGE_USAGE));
+    }
+
 }


### PR DESCRIPTION
Modify range command to reject invalid inputs for the range such as alphabets or negative numbers

closes #169 
closes #121 
closes #123 