### PR TITLE
Clip long text fields in property and client cards

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,8 @@ dependencies {
     implementation group: 'org.openjfx', name: 'javafx-web', version: javaFxVersion, classifier: 'mac'
     implementation group: 'org.openjfx', name: 'javafx-web', version: javaFxVersion, classifier: 'linux'
 
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
+
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.7.0'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'
 

--- a/src/main/java/seedu/condonery/ui/ClientCard.java
+++ b/src/main/java/seedu/condonery/ui/ClientCard.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.Comparator;
 
+import org.apache.commons.lang3.StringUtils;
+
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.image.Image;
@@ -56,8 +58,8 @@ public class ClientCard extends UiPart<Region> {
         super(FXML);
         this.client = client;
         id.setText(displayedIndex + ". ");
-        name.setText(client.getName().fullName);
-        address.setText(client.getAddress().value);
+        name.setText(StringUtils.abbreviate(client.getName().fullName, 140));
+        address.setText(StringUtils.abbreviate(client.getAddress().value, 140));
         client.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/java/seedu/condonery/ui/ClientCard.java
+++ b/src/main/java/seedu/condonery/ui/ClientCard.java
@@ -62,7 +62,7 @@ public class ClientCard extends UiPart<Region> {
         address.setText(StringUtils.abbreviate(client.getAddress().value, 140));
         client.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
-                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+                .forEach(tag -> tags.getChildren().add(new Label(StringUtils.abbreviate(tag.tagName, 15))));
         displayPicture.setClip(new Circle(40, 40, 40));
         Path imagePath = client.getImagePath();
         if (imagePath != null) {

--- a/src/main/java/seedu/condonery/ui/PropertyCard.java
+++ b/src/main/java/seedu/condonery/ui/PropertyCard.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.Comparator;
 
+import org.apache.commons.lang3.StringUtils;
+
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.image.Image;
@@ -57,8 +59,8 @@ public class PropertyCard extends UiPart<Region> {
         super(FXML);
         this.property = property;
         id.setText(displayedIndex + ". ");
-        name.setText(property.getName().fullName);
-        address.setText(property.getAddress().value);
+        name.setText(StringUtils.abbreviate(property.getName().fullName, 140));
+        address.setText(StringUtils.abbreviate(property.getAddress().value, 140));
         price.setText("$" + property.getPrice().value);
         property.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))

--- a/src/main/java/seedu/condonery/ui/PropertyCard.java
+++ b/src/main/java/seedu/condonery/ui/PropertyCard.java
@@ -64,7 +64,7 @@ public class PropertyCard extends UiPart<Region> {
         price.setText("$" + property.getPrice().value);
         property.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
-                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+                .forEach(tag -> tags.getChildren().add(new Label(StringUtils.abbreviate(tag.tagName, 15))));
         displayPicture.setClip(new Circle(40, 40, 40));
         propertyType.setText(property.getPropertyTypeEnum().toString());
         propertyStatus.setText(property.getPropertyStatusEnum().toString());


### PR DESCRIPTION
Clips text in names and addresses to 140 characters in property and client cards.
Clips text in tags to 15 characters in property and client cards. 

Uses Jakarta Commons [`StringUtils.abbreviate()`](http://commons.apache.org/proper/commons-lang/javadocs/api-3.1/org/apache/commons/lang3/StringUtils.html#abbreviate%28java.lang.String,%20int%29)

May need to go to File > Invalidate Caches in your IntelliJ IDE to install dependencies in `build.gradle`

Closes #181 
Closes #182 