### PR TITLE
Fix Updating associations after editing client name

### DIFF
--- a/src/main/java/seedu/condonery/logic/commands/client/AddClientCommand.java
+++ b/src/main/java/seedu/condonery/logic/commands/client/AddClientCommand.java
@@ -28,7 +28,7 @@ public class AddClientCommand extends Command {
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_ADDRESS + "ADDRESS "
-            + "[" + PREFIX_TAG + "TAG] "
+            + "[" + PREFIX_TAG + "TAG]... "
             + "[" + PREFIX_INTERESTEDPROPERTIES + "INTERESTED_PROPERTIES]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "Alice Tan "

--- a/src/main/java/seedu/condonery/logic/commands/client/EditClientCommand.java
+++ b/src/main/java/seedu/condonery/logic/commands/client/EditClientCommand.java
@@ -5,6 +5,7 @@ import static seedu.condonery.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.condonery.logic.parser.CliSyntax.PREFIX_INTERESTEDPROPERTIES;
 import static seedu.condonery.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.condonery.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.condonery.model.Model.PREDICATE_SHOW_ALL_CLIENTS;
 import static seedu.condonery.model.Model.PREDICATE_SHOW_ALL_PROPERTIES;
 
 import java.io.File;
@@ -41,7 +42,7 @@ public class EditClientCommand extends Command {
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_ADDRESS + "ADDRESS "
-            + "[" + PREFIX_TAG + "TAG] "
+            + "[" + PREFIX_TAG + "TAG]... "
             + "[" + PREFIX_INTERESTEDPROPERTIES + "INTERESTED_PROPERTIES]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "Alice Tan"
@@ -130,6 +131,7 @@ public class EditClientCommand extends Command {
 
         model.setClient(clientToEdit, editedClient);
         model.updateFilteredPropertyList(PREDICATE_SHOW_ALL_PROPERTIES);
+        model.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
 
         if (this.hasImage) {
             return new CommandResult(

--- a/src/main/java/seedu/condonery/logic/commands/property/AddPropertyCommand.java
+++ b/src/main/java/seedu/condonery/logic/commands/property/AddPropertyCommand.java
@@ -35,7 +35,7 @@ public class AddPropertyCommand extends Command {
             + PREFIX_PRICE + "PRICE "
             + "[" + PREFIX_IMAGE_UPLOAD + "] "
             + "[" + PREFIX_PROPERTY_STATUS + "PROPERTY_STATUS] "
-            + "[" + PREFIX_INTERESTEDCLIENTS + "INTERESTED_CLIENT ]"
+            + "[" + PREFIX_INTERESTEDCLIENTS + "INTERESTED_CLIENT]... "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "PINNACLE@DUXTON "

--- a/src/main/java/seedu/condonery/logic/commands/property/EditPropertyCommand.java
+++ b/src/main/java/seedu/condonery/logic/commands/property/EditPropertyCommand.java
@@ -9,6 +9,7 @@ import static seedu.condonery.logic.parser.CliSyntax.PREFIX_PRICE;
 import static seedu.condonery.logic.parser.CliSyntax.PREFIX_PROPERTY_STATUS;
 import static seedu.condonery.logic.parser.CliSyntax.PREFIX_PROPERTY_TYPE;
 import static seedu.condonery.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.condonery.model.Model.PREDICATE_SHOW_ALL_CLIENTS;
 import static seedu.condonery.model.Model.PREDICATE_SHOW_ALL_PROPERTIES;
 
 import java.io.File;
@@ -50,10 +51,10 @@ public class EditPropertyCommand extends Command {
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_PRICE + "PRICE] "
-            + "[" + PREFIX_TAG + "TAG] "
             + "[" + PREFIX_IMAGE_UPLOAD + "] "
             + "[" + PREFIX_PROPERTY_TYPE + "PROPERTY_TYPE] "
             + "[" + PREFIX_PROPERTY_STATUS + "PROPERTY_STATUS] "
+            + "[" + PREFIX_TAG + "TAG]... "
             + "[" + PREFIX_INTERESTEDCLIENTS + "INTERESTED-CLIENTS]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_NAME + "Pinnacle@Duxton";
@@ -142,11 +143,12 @@ public class EditPropertyCommand extends Command {
 
         File existingImage = new File(propertyToEdit.getImagePath().toString());
         if (existingImage.exists()) {
-            existingImage.renameTo(new File(editedProperty.getImagePath().toString()));
+            existingImage.renameTo(new File(newEditedProperty.getImagePath().toString()));
         }
 
         model.setProperty(propertyToEdit, newEditedProperty);
         model.updateFilteredPropertyList(PREDICATE_SHOW_ALL_PROPERTIES);
+        model.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
 
         if (this.hasImage) {
             return new CommandResult(

--- a/src/main/java/seedu/condonery/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/condonery/logic/parser/ParserUtil.java
@@ -147,6 +147,9 @@ public class ParserUtil {
         requireNonNull(clients);
         final Set<Client> clientSet = new HashSet<>();
         for (String clientName : clients) {
+            if (clientName.equals("")) {
+                continue;
+            }
             clientSet.add(parseClientName(clientName));
         }
         return clientSet;

--- a/src/main/java/seedu/condonery/model/ModelManager.java
+++ b/src/main/java/seedu/condonery/model/ModelManager.java
@@ -241,6 +241,7 @@ public class ModelManager implements Model {
     public void setClient(Client target, Client editedClient) {
         requireAllNonNull(target, editedClient);
         clientDirectory.setClient(target, editedClient);
+        propertyDirectory.updateClient(target, editedClient);
     }
 
     @Override

--- a/src/main/java/seedu/condonery/model/property/PropertyDirectory.java
+++ b/src/main/java/seedu/condonery/model/property/PropertyDirectory.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import javafx.collections.ObservableList;
+import seedu.condonery.model.client.Client;
 import seedu.condonery.model.property.exceptions.UniquePropertyNotFoundException;
 
 /**
@@ -132,6 +133,14 @@ public class PropertyDirectory implements ReadOnlyPropertyDirectory {
      */
     public Property getUniquePropertyByName(String substring) throws UniquePropertyNotFoundException {
         return properties.getUniquePropertyByName(substring);
+    }
+
+    /**
+     * Edits the client references in all Properties
+     * @param originalClient
+     */
+    public void updateClient(Client originalClient, Client editedClient) {
+        properties.updateClient(originalClient, editedClient);
     }
 
     @Override

--- a/src/main/java/seedu/condonery/model/property/UniquePropertyList.java
+++ b/src/main/java/seedu/condonery/model/property/UniquePropertyList.java
@@ -5,9 +5,11 @@ import static seedu.condonery.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.condonery.model.client.Client;
 import seedu.condonery.model.property.exceptions.DuplicatePropertyException;
 import seedu.condonery.model.property.exceptions.PropertyNotFoundException;
 import seedu.condonery.model.property.exceptions.UniquePropertyNotFoundException;
@@ -149,6 +151,22 @@ public class UniquePropertyList implements Iterable<Property> {
             throw new UniquePropertyNotFoundException();
         } else {
             return uniqueProperty;
+        }
+    }
+
+    /**
+     * Edits the client references in all Properties
+     * @param originalClient
+     */
+    public void updateClient(Client originalClient, Client editedClient) {
+        requireAllNonNull(originalClient, editedClient);
+
+        for (Property property : internalList) {
+            Set<Client> interestedClients = property.getInterestedClients();
+            if (interestedClients.contains(originalClient)) {
+                interestedClients.remove(originalClient);
+                interestedClients.add(editedClient);
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes miscellaneous bugs, such as the interested clients not updating after editing a client name.

To test:
`edit -p 1 ic/Alice` 
`edit -p [ALICE_INDEX] n/Bobby`
`select -p 1` 

Bobby is no longer an interested client for the property, even though we just updated the name only.

I also fixed miscellaneous bugs like the property image disappearing after updating the name, and I cleared the predicate for both Client and Property Directory after any edit command.